### PR TITLE
feat: add commune status layer

### DIFF
--- a/public/styles/ortho.json
+++ b/public/styles/ortho.json
@@ -17,7 +17,8 @@
     },
     "decoupage-administratif": {
       "type": "vector",
-      "url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+      "tiles": ["https://openmaptiles.data.gouv.fr/data/decoupage-administratif/{z}/{x}/{y}.pbf"],
+      "maxzoom": 12
     }
   },
   "layers": [

--- a/src/api/signalement/services/SettingsService.ts
+++ b/src/api/signalement/services/SettingsService.ts
@@ -87,6 +87,17 @@ export class SettingsService {
         });
     }
     /**
+     * Get the settings of all communes
+     * @returns CommuneSettingsDTO Map of commune codes to their settings
+     * @throws ApiError
+     */
+    public static getAllCommuneSettings(): CancelablePromise<Record<string, CommuneSettingsDTO>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/settings/commune-settings',
+        });
+    }
+    /**
      * Check if the given id is in the enabled list for the given listKey
      * @param listKey
      * @param id

--- a/src/api/signalement/services/TilesService.ts
+++ b/src/api/signalement/services/TilesService.ts
@@ -37,27 +37,4 @@ export class TilesService {
             },
         });
     }
-    /**
-     * Get vector tiles with commune status (enabled communes)
-     * @param z
-     * @param x
-     * @param y
-     * @returns any PBF vector tile with commune-status layer
-     * @throws ApiError
-     */
-    public static getCommuneStatusTiles(
-        z: string,
-        x: string,
-        y: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/tiles/commune-status/{z}/{x}/{y}.pbf',
-            path: {
-                'z': z,
-                'x': x,
-                'y': y,
-            },
-        });
-    }
 }

--- a/src/api/signalement/services/TilesService.ts
+++ b/src/api/signalement/services/TilesService.ts
@@ -38,8 +38,7 @@ export class TilesService {
         });
     }
     /**
-     * Get vector tiles with commune status (enabled communes for a given source)
-     * @param sourceId Source ID to filter commune status
+     * Get vector tiles with commune status (enabled communes)
      * @param z
      * @param x
      * @param y
@@ -47,7 +46,6 @@ export class TilesService {
      * @throws ApiError
      */
     public static getCommuneStatusTiles(
-        sourceId: string,
         z: string,
         x: string,
         y: string,
@@ -59,9 +57,6 @@ export class TilesService {
                 'z': z,
                 'x': x,
                 'y': y,
-            },
-            query: {
-                'sourceId': sourceId,
             },
         });
     }

--- a/src/api/signalement/services/TilesService.ts
+++ b/src/api/signalement/services/TilesService.ts
@@ -12,7 +12,7 @@ export class TilesService {
      * @param x
      * @param y
      * @param status Filter by status
-     * @param layers Layers to include in the tiles (defaults to both alerts and signalements)
+     * @param layers Layers to include in the tiles (defaults to alerts and signalements)
      * @returns any PBF vector tile with requested layers
      * @throws ApiError
      */
@@ -34,6 +34,34 @@ export class TilesService {
             query: {
                 'status': status,
                 'layers': layers,
+            },
+        });
+    }
+    /**
+     * Get vector tiles with commune status (enabled communes for a given source)
+     * @param sourceId Source ID to filter commune status
+     * @param z
+     * @param x
+     * @param y
+     * @returns any PBF vector tile with commune-status layer
+     * @throws ApiError
+     */
+    public static getCommuneStatusTiles(
+        sourceId: string,
+        z: string,
+        x: string,
+        y: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/tiles/commune-status/{z}/{x}/{y}.pbf',
+            path: {
+                'z': z,
+                'x': x,
+                'y': y,
+            },
+            query: {
+                'sourceId': sourceId,
             },
         });
     }

--- a/src/composants/map/SignalementsSearchMap.tsx
+++ b/src/composants/map/SignalementsSearchMap.tsx
@@ -1,9 +1,11 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { Layer, LayerProps, MapLayerMouseEvent, Popup, Source, useMap } from 'react-map-gl/maplibre'
 import {
   alertPointsLayer,
   APISignalementTiles,
   signalementPointsLayer,
+  communeStatusLayer,
+  getAPICommuneStatusTiles,
 } from '../../config/map/layers'
 import { Alert, Signalement } from '../../api/signalement'
 import SignalementCard from '../signalement/SignalementCard'
@@ -11,6 +13,7 @@ import { getSignalementFromFeatureAPISignalement } from '../../utils/signalement
 import { getAlertFromFeatureAPISignalement } from '../../utils/alert.utils'
 import AlertCard from '../alert/AlertCard'
 import { SignalementViewerContext } from '../../contexts/signalement-viewer.context'
+import SourceContext from '../../contexts/source.context'
 
 interface SignalementSearchMapProps {
   options: Partial<LayerProps>
@@ -29,6 +32,13 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
     data: Signalement | Alert
     point: any
   } | null>(null)
+  const { source } = useContext(SourceContext)
+
+  const apiCommuneStatusTiles = useMemo(
+    () =>
+      getAPICommuneStatusTiles(source?.id || `${process.env.REACT_APP_API_SIGNALEMENT_SOURCE_ID}`),
+    [source?.id],
+  )
 
   useEffect(() => {
     if (!map.current) {
@@ -132,6 +142,16 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
       >
         <Layer key={signalementPointsLayer.id} {...(signalementPointsLayer as any)} {...options} />
         <Layer key={alertPointsLayer.id} {...(alertPointsLayer as any)} {...options} />
+      </Source>
+      <Source
+        id='api-commune-status'
+        type='vector'
+        tiles={apiCommuneStatusTiles}
+        minzoom={5}
+        maxzoom={20}
+        promoteId='id'
+      >
+        <Layer key={communeStatusLayer.id} {...(communeStatusLayer as any)} {...options} />
       </Source>
     </>
   )

--- a/src/composants/map/SignalementsSearchMap.tsx
+++ b/src/composants/map/SignalementsSearchMap.tsx
@@ -3,11 +3,10 @@ import { Layer, LayerProps, MapLayerMouseEvent, Popup, Source, useMap } from 're
 import {
   alertPointsLayer,
   APISignalementTiles,
-  APICommuneStatusTiles,
   signalementPointsLayer,
   getCommuneStatusLayer,
 } from '../../config/map/layers'
-import { Alert, Signalement } from '../../api/signalement'
+import { Alert, CommuneSettingsDTO, SettingsService, Signalement } from '../../api/signalement'
 import SignalementCard from '../signalement/SignalementCard'
 import { getSignalementFromFeatureAPISignalement } from '../../utils/signalement.utils'
 import { getAlertFromFeatureAPISignalement } from '../../utils/alert.utils'
@@ -27,12 +26,26 @@ enum FeatureType {
 export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMapProps>) {
   const map = useMap()
   const { setViewedSignalement } = useContext(SignalementViewerContext)
+  const [communeSettings, setCommuneSettings] = useState<Record<string, CommuneSettingsDTO>>({})
   const [hoveredFeature, setHoveredFeature] = useState<{
     type: FeatureType
     data: Signalement | Alert
     point: any
   } | null>(null)
   const { source } = useContext(SourceContext)
+
+  // Fetch commune settings on mount
+  useEffect(() => {
+    const fetchCommuneSettings = async () => {
+      try {
+        const settings = await SettingsService.getAllCommuneSettings()
+        setCommuneSettings(settings)
+      } catch (error) {
+        console.error('Error fetching commune settings:', error)
+      }
+    }
+    fetchCommuneSettings()
+  }, [])
 
   const communeStatusLayer = useMemo(
     () =>
@@ -89,7 +102,40 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
       }
     }
 
-    if (map?.current) {
+    const applySettings = () => {
+      if (!map.current?.isSourceLoaded('decoupage-administratif')) {
+        return
+      }
+
+      for (const [codeCommune, status] of Object.entries(communeSettings)) {
+        map.current.setFeatureState(
+          { source: 'decoupage-administratif', sourceLayer: 'communes', id: codeCommune },
+          {
+            disabled: status.disabled,
+            mode: status.mode || null,
+            filteredSources: status.filteredSources?.join(',') || null,
+          },
+        )
+      }
+
+      map.current.off('sourcedata', onSourceData)
+    }
+
+    const onSourceData = (e: any) => {
+      if (e.sourceId === 'decoupage-administratif' && e.isSourceLoaded) {
+        applySettings()
+      }
+    }
+
+    if (Object.keys(communeSettings).length > 0) {
+      if (map.current.isSourceLoaded('decoupage-administratif')) {
+        applySettings()
+      } else {
+        map.current.on('sourcedata', onSourceData)
+      }
+    }
+
+    if (map.current) {
       map.current.on('click', signalementPointsLayer.id, handleSelect)
       map.current.on('mousemove', signalementPointsLayer.id, handleMouseMove)
       map.current.on('mouseleave', signalementPointsLayer.id, handleMouseLeave)
@@ -100,6 +146,7 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
 
     return () => {
       if (map?.current) {
+        map.current.off('sourcedata', onSourceData)
         map.current.off('click', signalementPointsLayer.id, handleSelect)
         map.current.off('mousemove', signalementPointsLayer.id, handleMouseMove)
         map.current.off('mouseleave', signalementPointsLayer.id, handleMouseLeave)
@@ -108,7 +155,7 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
         map.current.off('mouseleave', alertPointsLayer.id, handleMouseLeave)
       }
     }
-  }, [map])
+  }, [map, communeSettings])
 
   return (
     <>
@@ -146,12 +193,11 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
         <Layer key={alertPointsLayer.id} {...(alertPointsLayer as any)} {...options} />
       </Source>
       <Source
-        id='api-commune-status'
+        id='decoupage-administratif'
         type='vector'
-        tiles={APICommuneStatusTiles}
-        minzoom={5}
-        maxzoom={20}
-        promoteId='id'
+        tiles={['https://openmaptiles.data.gouv.fr/data/decoupage-administratif/{z}/{x}/{y}.pbf']}
+        maxzoom={11}
+        promoteId='code'
       >
         <Layer key={communeStatusLayer.id} {...(communeStatusLayer as any)} {...options} />
       </Source>

--- a/src/composants/map/SignalementsSearchMap.tsx
+++ b/src/composants/map/SignalementsSearchMap.tsx
@@ -196,7 +196,7 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
         id='decoupage-administratif'
         type='vector'
         tiles={['https://openmaptiles.data.gouv.fr/data/decoupage-administratif/{z}/{x}/{y}.pbf']}
-        maxzoom={11}
+        maxzoom={12}
         promoteId='code'
       >
         <Layer key={communeStatusLayer.id} {...(communeStatusLayer as any)} {...options} />

--- a/src/composants/map/SignalementsSearchMap.tsx
+++ b/src/composants/map/SignalementsSearchMap.tsx
@@ -3,9 +3,9 @@ import { Layer, LayerProps, MapLayerMouseEvent, Popup, Source, useMap } from 're
 import {
   alertPointsLayer,
   APISignalementTiles,
+  APICommuneStatusTiles,
   signalementPointsLayer,
-  communeStatusLayer,
-  getAPICommuneStatusTiles,
+  getCommuneStatusLayer,
 } from '../../config/map/layers'
 import { Alert, Signalement } from '../../api/signalement'
 import SignalementCard from '../signalement/SignalementCard'
@@ -34,10 +34,12 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
   } | null>(null)
   const { source } = useContext(SourceContext)
 
-  const apiCommuneStatusTiles = useMemo(
+  const communeStatusLayer = useMemo(
     () =>
-      getAPICommuneStatusTiles(source?.id || `${process.env.REACT_APP_API_SIGNALEMENT_SOURCE_ID}`),
-    [source?.id],
+      getCommuneStatusLayer(
+        source?.id || `${process.env.REACT_APP_API_SIGNALEMENT_SOURCE_ID}`,
+      ) as Partial<LayerProps>,
+    [source],
   )
 
   useEffect(() => {
@@ -146,7 +148,7 @@ export function SignalementsSearchMap({ options }: Readonly<SignalementSearchMap
       <Source
         id='api-commune-status'
         type='vector'
-        tiles={apiCommuneStatusTiles}
+        tiles={APICommuneStatusTiles}
         minzoom={5}
         maxzoom={20}
         promoteId='id'

--- a/src/config/map/layers.ts
+++ b/src/config/map/layers.ts
@@ -285,16 +285,12 @@ export const getCommuneStatusLayer = (sourceId: string) => ({
   paint: {
     'fill-color': [
       'case',
-      // Source filtrée → gris
       ['in', sourceId, ['to-string', ['feature-state', 'filteredSources']]],
       '#cecece',
-      // Mode FULL → bleu foncé
       ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.FULL],
       'transparent',
-      // Mode LIGHT → bleu clair
       ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.LIGHT],
       'transparent',
-      // Disabled / défaut → gris
       '#cecece',
     ],
     'fill-opacity': ['interpolate', ['linear'], ['zoom'], 7, 0.1, 8, 0.5, 11, 0.1],

--- a/src/config/map/layers.ts
+++ b/src/config/map/layers.ts
@@ -278,20 +278,26 @@ export const alertPointsLayer = {
 
 export const getCommuneStatusLayer = (sourceId: string) => ({
   id: 'commune-status-polygons',
-  source: 'api-commune-status',
-  'source-layer': 'commune-status',
+  source: 'decoupage-administratif',
+  'source-layer': 'communes',
   type: 'fill',
   maxzoom: 11,
-  minzoom: 7,
   paint: {
     'fill-color': [
       'case',
-      ['all', ['has', 'filteredSources'], ['in', sourceId, ['get', 'filteredSources']]],
+      // Pas de statut connu → gris
+      ['!', ['to-boolean', ['feature-state', 'mode']]],
       '#cecece',
-      ['==', ['get', 'mode'], CommuneStatusDTO.mode.FULL],
+      // Source filtrée → gris
+      ['in', sourceId, ['to-string', ['feature-state', 'filteredSources']]],
+      '#cecece',
+      // Mode FULL → bleu foncé
+      ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.FULL],
       '#2564a0',
-      ['==', ['get', 'mode'], CommuneStatusDTO.mode.LIGHT],
+      // Mode LIGHT → bleu clair
+      ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.LIGHT],
       '#3288bd',
+      // Disabled / défaut → gris
       '#cecece',
     ],
     'fill-opacity': ['interpolate', ['linear'], ['zoom'], 7, 0.1, 8, 0.5, 11, 0.1],

--- a/src/config/map/layers.ts
+++ b/src/config/map/layers.ts
@@ -285,18 +285,15 @@ export const getCommuneStatusLayer = (sourceId: string) => ({
   paint: {
     'fill-color': [
       'case',
-      // Pas de statut connu → gris
-      ['!', ['to-boolean', ['feature-state', 'mode']]],
-      '#cecece',
       // Source filtrée → gris
       ['in', sourceId, ['to-string', ['feature-state', 'filteredSources']]],
       '#cecece',
       // Mode FULL → bleu foncé
       ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.FULL],
-      '#2564a0',
+      'transparent',
       // Mode LIGHT → bleu clair
       ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.LIGHT],
-      '#3288bd',
+      'transparent',
       // Disabled / défaut → gris
       '#cecece',
     ],

--- a/src/config/map/layers.ts
+++ b/src/config/map/layers.ts
@@ -1,4 +1,4 @@
-import { Signalement } from '../../api/signalement'
+import { CommuneStatusDTO, Signalement } from '../../api/signalement'
 
 // DSFR default blue color
 export const DEFAULT_COLOR_DARK = '#000091'
@@ -17,6 +17,10 @@ export const PARCELLES_MINZOOM = 14
 
 export const APISignalementTiles = [
   `${process.env.REACT_APP_API_SIGNALEMENT_URL}/tiles/{z}/{x}/{y}.pbf?status=${Signalement.status.PENDING}`,
+]
+
+export const getAPICommuneStatusTiles = (sourceId: string) => [
+  `${process.env.REACT_APP_API_SIGNALEMENT_URL}/tiles/commune-status/{z}/{x}/{y}.pbf?sourceId=${sourceId}`,
 ]
 
 export const adresseCircleLayer = {
@@ -269,6 +273,25 @@ export const alertPointsLayer = {
     'icon-image': 'alert-flag',
     'icon-anchor': 'bottom',
     'icon-size': 0.4,
+  },
+}
+
+export const communeStatusLayer = {
+  id: 'commune-status-polygons',
+  source: 'api-commune-status',
+  'source-layer': 'commune-status',
+  type: 'fill',
+  maxzoom: 10,
+  paint: {
+    'fill-color': [
+      'case',
+      ['==', ['get', 'mode'], CommuneStatusDTO.mode.FULL],
+      '#3288bd',
+      ['==', ['get', 'mode'], CommuneStatusDTO.mode.LIGHT],
+      '#3288bd',
+      '#999999',
+    ],
+    'fill-opacity': ['interpolate', ['exponential', 0.5], ['zoom'], 5, 0.9, 15, 0.5],
   },
 }
 

--- a/src/config/map/layers.ts
+++ b/src/config/map/layers.ts
@@ -289,7 +289,7 @@ export const getCommuneStatusLayer = (sourceId: string) => ({
       ['all', ['has', 'filteredSources'], ['in', sourceId, ['get', 'filteredSources']]],
       '#cecece',
       ['==', ['get', 'mode'], CommuneStatusDTO.mode.FULL],
-      '#3288bd',
+      '#2564a0',
       ['==', ['get', 'mode'], CommuneStatusDTO.mode.LIGHT],
       '#3288bd',
       '#cecece',

--- a/src/config/map/layers.ts
+++ b/src/config/map/layers.ts
@@ -19,8 +19,8 @@ export const APISignalementTiles = [
   `${process.env.REACT_APP_API_SIGNALEMENT_URL}/tiles/{z}/{x}/{y}.pbf?status=${Signalement.status.PENDING}`,
 ]
 
-export const getAPICommuneStatusTiles = (sourceId: string) => [
-  `${process.env.REACT_APP_API_SIGNALEMENT_URL}/tiles/commune-status/{z}/{x}/{y}.pbf?sourceId=${sourceId}`,
+export const APICommuneStatusTiles = [
+  `${process.env.REACT_APP_API_SIGNALEMENT_URL}/tiles/commune-status/{z}/{x}/{y}.pbf`,
 ]
 
 export const adresseCircleLayer = {
@@ -276,24 +276,27 @@ export const alertPointsLayer = {
   },
 }
 
-export const communeStatusLayer = {
+export const getCommuneStatusLayer = (sourceId: string) => ({
   id: 'commune-status-polygons',
   source: 'api-commune-status',
   'source-layer': 'commune-status',
   type: 'fill',
-  maxzoom: 10,
+  maxzoom: 11,
+  minzoom: 7,
   paint: {
     'fill-color': [
       'case',
+      ['all', ['has', 'filteredSources'], ['in', sourceId, ['get', 'filteredSources']]],
+      '#cecece',
       ['==', ['get', 'mode'], CommuneStatusDTO.mode.FULL],
       '#3288bd',
       ['==', ['get', 'mode'], CommuneStatusDTO.mode.LIGHT],
       '#3288bd',
-      '#999999',
+      '#cecece',
     ],
-    'fill-opacity': ['interpolate', ['exponential', 0.5], ['zoom'], 5, 0.9, 15, 0.5],
+    'fill-opacity': ['interpolate', ['linear'], ['zoom'], 7, 0.1, 8, 0.5, 11, 0.1],
   },
-}
+})
 
 export const clusters = {
   id: 'clusters',

--- a/src/config/map/layers.ts
+++ b/src/config/map/layers.ts
@@ -281,19 +281,18 @@ export const getCommuneStatusLayer = (sourceId: string) => ({
   source: 'decoupage-administratif',
   'source-layer': 'communes',
   type: 'fill',
-  maxzoom: 11,
   paint: {
     'fill-color': [
       'case',
       ['in', sourceId, ['to-string', ['feature-state', 'filteredSources']]],
-      '#cecece',
+      '#b0b0b0',
       ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.FULL],
       'transparent',
       ['==', ['feature-state', 'mode'], CommuneStatusDTO.mode.LIGHT],
       'transparent',
-      '#cecece',
+      '#b0b0b0',
     ],
-    'fill-opacity': ['interpolate', ['linear'], ['zoom'], 7, 0.1, 8, 0.5, 11, 0.1],
+    'fill-opacity': ['interpolate', ['linear'], ['zoom'], 8, 0.5, 12, 0.3],
   },
 })
 


### PR DESCRIPTION
Ajoute un layer "commune-status" qui permet de voir sur la carte les communes où le signalement est activé

<img width="1477" height="834" alt="Capture d’écran 2026-03-27 à 14 40 40" src="https://github.com/user-attachments/assets/46e448ab-caa9-4b77-bcc6-248dde6db3ad" />

PR back : https://github.com/BaseAdresseNationale/api-signalement/pull/44
PR Api-dépot : https://github.com/BaseAdresseNationale/api-depot/pull/172
